### PR TITLE
get consignment-view title + details from contentful

### DIFF
--- a/less/site.less
+++ b/less/site.less
@@ -284,7 +284,6 @@ ul.events-menu li {
   background: #fff;
   // display: inline-block;
   z-index: 1000; /* so the menu or its navicon stays above all content */
-  overflow-y: auto;
   -webkit-overflow-scrolling: touch;
   ul li {
     list-style-type: none;

--- a/resources/public/css/site.css
+++ b/resources/public/css/site.css
@@ -262,7 +262,6 @@ ul.events-menu li a {
   background: #fff;
   z-index: 1000;
   /* so the menu or its navicon stays above all content */
-  overflow-y: auto;
   -webkit-overflow-scrolling: touch;
 }
 #nav-wrapper ul li {

--- a/src/cljs/playground_coffeeshop/db.cljs
+++ b/src/cljs/playground_coffeeshop/db.cljs
@@ -8,4 +8,5 @@
    :on-event-details-render nil
    :on-about-entry-render nil
    :on-menus-entry-render nil
-   :on-slide-show-images nil})
+   :on-slide-show-images nil
+   :on-consignment-entry-render nil})

--- a/src/cljs/playground_coffeeshop/handlers.cljs
+++ b/src/cljs/playground_coffeeshop/handlers.cljs
@@ -125,11 +125,13 @@
   (fn [db [_ response]]
     (let [response-items (:items response)
 
-          about-items (filter-items = "about" response-items)
+          about-item (-> (filter-items = "about" response-items)
+                         first)
 
           menu-items (filter-items = "menu" response-items)
 
-          consignment-items (filter-items = "consignment" response-items)
+          consignment-item (-> (filter-items = "consignment" response-items)
+                               first)
 
           slide-show-items (-> (filter-items = "slideShow" response-items)
                                first
@@ -140,7 +142,7 @@
 
           menu-item-asset-ids (mapv #(get-in % [:fields :pdf :sys :id]) menu-items)
 
-          consignment-item-asset-ids (mapv #(get-in % [:fields :pdf :sys :id]) consignment-items)
+          consignment-item-asset-id (get-in consignment-item [:fields :pdf :sys :id])
 
           slide-show-asset-ids (->> slide-show-items
                                     (map :sys)
@@ -158,15 +160,16 @@
                                             (get-in % [:fields :file :url])) assets))
                                   menu-item-asset-ids)
 
-          match-consignment-assets (mapv (fn [id]
-                                          (some #(when (= id (get-in % [:sys :id]))
-                                                   (get-in % [:fields :file :url])) assets))
-                                         consignment-item-asset-ids)]
+          match-consignment-assets  (some #(when (= consignment-item-asset-id (get-in % [:sys :id]))
+                                             (get-in % [:fields :file :url])) assets)
+
+          final-consigment-data (assoc consignment-item
+                                  :consignment-asset match-consignment-assets)]
 
       (-> db
           (assoc :on-slide-show-images  match-slide-show-assets
-                 :on-about-entry-render about-items
-                 :on-consignment-entry-render (zipmap consignment-items match-consignment-assets)
+                 :on-about-entry-render about-item
+                 :on-consignment-entry-render final-consigment-data
                  :on-menus-entry-render (zipmap menu-item-titles match-menu-assets))))))
 
 (re-frame/register-handler

--- a/src/cljs/playground_coffeeshop/views/about.cljs
+++ b/src/cljs/playground_coffeeshop/views/about.cljs
@@ -1,6 +1,5 @@
 (ns playground-coffeeshop.views.about
   (:require [re-frame.core :as re-frame]
-            [cljsjs.marked]
             [reagent.core :as reagent]))
 
 (defn about-view []
@@ -12,7 +11,7 @@
            (re-frame/dispatch [:get-site-cms-data])))
        :reagent-render
        (fn []
-         (let [{:keys [title description]} (:fields (first @about))]
+         (let [{:keys [title description]} (:fields @about)]
            [:div
             [:h3 title]
             [:p description]]))})))

--- a/src/cljs/playground_coffeeshop/views/consignment.cljs
+++ b/src/cljs/playground_coffeeshop/views/consignment.cljs
@@ -1,6 +1,7 @@
 (ns playground-coffeeshop.views.consignment
   (:require [re-frame.core :as re-frame]
-            [reagent.core :as reagent]))
+            [reagent.core :as reagent]
+            [cljsjs.marked]))
 
 (defn consignment-view []
   (let [consignment (re-frame/subscribe [:on-consignment-entry-render])]
@@ -11,13 +12,15 @@
            (re-frame/dispatch [:get-site-cms-data])))
        :reagent-render
        (fn []
-         (let [link (first @consignment)]
+         (let [title (get-in (first (first @consignment)) [:fields :title])
+               details (get-in (first (first @consignment)) [:fields :details])
+               link (second (first @consignment))]
            [:div
-            [:h3 "Sell with us!"]
-            [:p "We are accepting zines, cassettes, vinyl records, vhs tapes, cds, prints, etc for consignment."]
-            [:p "Please send completed consignment form to "
-             [:a {:href "mailto:general@playgroundcoffeeshop.com"} "general@playgroundcoffeeshop.com"]
-             " along with images of your work."]
-            [:br]
-            [:a.button-link {:href link :target "_blank"}
-             [:b "Download Form"]]]))})))
+            [:h3 title]
+
+            [:div {"dangerouslySetInnerHTML"
+                   #js{:__html (js/marked details)}}]
+
+            [:p {:style {:margin-top "27px"}}
+              [:a.button-link {:href link :target "_blank"}
+                [:b "Download Form"]]]]))})))

--- a/src/cljs/playground_coffeeshop/views/consignment.cljs
+++ b/src/cljs/playground_coffeeshop/views/consignment.cljs
@@ -12,15 +12,16 @@
            (re-frame/dispatch [:get-site-cms-data])))
        :reagent-render
        (fn []
-         (let [title (get-in (first (first @consignment)) [:fields :title])
-               details (get-in (first (first @consignment)) [:fields :details])
-               link (second (first @consignment))]
-           [:div
-            [:h3 title]
+         (when @consignment
+           (let [title (get-in @consignment [:fields :title])
+                 details (get-in @consignment [:fields :details])
+                 link (@consignment :consignment-asset)]
+             [:div
+              [:h3 title]
 
-            [:div {"dangerouslySetInnerHTML"
-                   #js{:__html (js/marked details)}}]
+              [:div {"dangerouslySetInnerHTML"
+                     #js{:__html (js/marked details)}}]
 
-            [:p {:style {:margin-top "27px"}}
-              [:a.button-link {:href link :target "_blank"}
-                [:b "Download Form"]]]]))})))
+              [:p {:style {:margin-top "27px"}}
+               [:a.button-link {:href link :target "_blank"}
+                [:b "Download Form"]]]])))})))


### PR DESCRIPTION
@dviramontes i think this part can be improved in the handler:

`:on-consignment-entry-render (zipmap consignment-items match-consignment-assets)`

it returns
```
{{:fields {:pdf {:sys {:type "Link", :id "6DbvKK5iLeKkyOw8406eek", :linkType "Asset"}},
           :title "Sell with us!",
           :details "We are accepting zines, cassettes, vinyl records, vhs tapes, cds, prints, etc for consignment.\n\nPlease send completed consignment form to [general@playgroundcoffeeshop.com](mailto:general@playgroundcoffeeshop.com) along with images of your work."},
  :sys {:space {:sys {:type "Link", :id "3tvj6ug2yrmi", :linkType "Space"}},
        :updatedAt "2016-12-09T23:09:06.074Z",
        :revision 1,
        :locale "en-US",
        :createdAt "2016-12-09T23:09:06.074Z",
        :type "Entry",
        :id "1lWXGQfR2ASWeiiOgKMoSE",
        :contentType {:sys {:type "Link", :id "consignment", :linkType "ContentType"}}}} "//assets.contentful.com/3tvj6ug2yrmi/6DbvKK5iLeKkyOw8406eek/a75b85187cb594ed6d8be4b9ff8f35ae/PLAYGROUNDCOFFEESHOPCONSIGNMENTPOLICY.pdf"}
```

and because of how that's structured, i have to use `first` twice in consignment.cljs:
```
         (let [title (get-in (first (first @consignment)) [:fields :title])
               details (get-in (first (first @consignment)) [:fields :details])
               link (second (first @consignment))]
```

let me know if you have any ideas