### PR TITLE
rename: news tab to blog

### DIFF
--- a/src/cljs/playground_coffeeshop/components/nav.cljs
+++ b/src/cljs/playground_coffeeshop/components/nav.cljs
@@ -9,7 +9,7 @@
        [:ul.nav
         [:li [:a {:href "/about"} "About"]]
         ; [:li [:a {:href "/menus"} "Menus"]]
-        [:li [:a {:href "/news"} "News"]]
+        [:li [:a {:href "/blog"} "Blog"]]
         [:ul.events-menu [:span [:a
                                  {:href     "/events"
                                   :on-click #(re-frame/dispatch [:display-filtered-events])} "Events"]]

--- a/src/cljs/playground_coffeeshop/routes.cljs
+++ b/src/cljs/playground_coffeeshop/routes.cljs
@@ -37,8 +37,8 @@
   ;; define routes here
   (defroute "/" []
             (re-frame/dispatch [:set-active-view :home-view]))
-  (defroute "/news" []
-            (re-frame/dispatch [:set-active-view :news-view]))
+  (defroute "/blog" []
+            (re-frame/dispatch [:set-active-view :blog-view]))
   (defroute "/about" []
             (re-frame/dispatch [:set-active-view :about-view]))
   (defroute "/menus" []

--- a/src/cljs/playground_coffeeshop/views.cljs
+++ b/src/cljs/playground_coffeeshop/views.cljs
@@ -4,7 +4,7 @@
             [playground-coffeeshop.components.nav :refer [nav-component]]
             [playground-coffeeshop.components.footer :refer [footer-component]]
             [playground-coffeeshop.views.about :refer [about-view]]
-            [playground-coffeeshop.views.news :refer [news-view]]
+            [playground-coffeeshop.views.blog :refer [blog-view]]
             [playground-coffeeshop.views.events :refer [events-view]]
             [playground-coffeeshop.views.bookings :refer [bookings-view]]
             [playground-coffeeshop.views.contact :refer [contact-view]]
@@ -15,7 +15,7 @@
 
 (defmulti views identity)
 (defmethod views :about-view [] [about-view])
-(defmethod views :news-view [] [news-view])
+(defmethod views :blog-view [] [blog-view])
 (defmethod views :events-view [] [events-view])
 (defmethod views :bookings-view [] [bookings-view])
 (defmethod views :contact-view [] [contact-view])

--- a/src/cljs/playground_coffeeshop/views/blog.cljs
+++ b/src/cljs/playground_coffeeshop/views/blog.cljs
@@ -1,9 +1,9 @@
-(ns playground-coffeeshop.views.news
+(ns playground-coffeeshop.views.blog
   (:require [re-frame.core :as re-frame]
             [reagent.core :as reagent]
             [playground-coffeeshop.components.news-article :refer [article]]))
 
-(defn news-view []
+(defn blog-view []
   (let [news (re-frame/subscribe [:on-news-entries-received])
         total (re-frame/subscribe [:on-news-entries-total-received])
         loading? (re-frame/subscribe [:on-news-entries-loading])]
@@ -15,7 +15,7 @@
        :reagent-render
        (fn []
          [:div.news-wrapper
-           [:h2 "News"]
+           [:h2 "Blog"]
            [:hr]
            (if (seq? @news)
              (let [articles @news]


### PR DESCRIPTION
Note: this change-set does not rename the css classes or the contentful variables. 